### PR TITLE
docs: add basic repository information

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,2 @@
+# Derived from MAINTAINERS.md
+* @shizhMSFT @Wwwsylvia

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,3 @@
+# Code of Conduct
+
+OCI Registry As Storage (ORAS) follows the [CNCF Code of Conduct](https://github.com/cncf/foundation/blob/master/code-of-conduct.md).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,3 @@
+# Contributing
+
+Please refer to the [ORAS Contributing guide](https://oras.land/docs/community/contributing_guide).

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -1,0 +1,5 @@
+# Maintainers
+
+Maintainers:
+- Shiwei Zhang (@shizhMSFT)
+- Sylvia Lei (@Wwwsylvia)

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,3 @@
+# Security Policy
+
+Please follow the [security policy](https://oras.land/docs/community/reporting_security_concerns) to report a security vulnerability or concern.


### PR DESCRIPTION
This pull request adds important community and project governance documentation files to the repository, including maintainers, code of conduct, contributing guidelines, security policy, and code ownership. These changes help establish clear guidelines for contributors and clarify project stewardship.

Project governance and ownership:

* Added `MAINTAINERS.md` listing Shiwei Zhang (@shizhMSFT) and Sylvia Lei (@Wwwsylvia) as project maintainers.
* Added `CODEOWNERS` file assigning all files to @shizhMSFT and @Wwwsylvia for code ownership.

Community guidelines and policies:

* Added `CODE_OF_CONDUCT.md` referencing the CNCF Code of Conduct to set expectations for community behavior.
* Added `CONTRIBUTING.md` with a link to the ORAS contributing guide for onboarding new contributors.
* Added `SECURITY.md` outlining the security policy and providing instructions for reporting vulnerabilities.