### PR TITLE
test: add code coverage reporting

### DIFF
--- a/.github/.codecov.yml
+++ b/.github/.codecov.yml
@@ -1,0 +1,23 @@
+# Copyright The ORAS Authors.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+coverage:
+  status:
+    project:
+      default:
+        target: 75%
+        if_ci_failed: error
+    patch:
+      default:
+        target: 80%
+        if_ci_failed: error

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -43,3 +43,9 @@ jobs:
         run: make test
       - name: Check Version
         run: bin/linux/amd64/oras-mcp version
+      - name: Upload coverage to codecov.io
+        uses: codecov/codecov-action@v4
+        env:
+          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+        with:
+          fail_ci_if_error: true


### PR DESCRIPTION
This pull request introduces code coverage reporting to the CI pipeline, ensuring that test coverage is tracked and maintained at a healthy threshold. The most important changes are grouped below:

**Continuous Integration Enhancements:**

* Added a step to the CI workflow in `.github/workflows/build.yml` to upload test coverage results to Codecov after running tests, using the official Codecov GitHub Action. This step will fail the CI if the upload encounters an error.

**Coverage Configuration:**

* Added a new `.github/.codecov.yml` configuration file to enforce minimum coverage thresholds: 75% for the overall project and 80% for code patches. If coverage falls below these targets or if CI fails, the build will error.