### PR TITLE
test: test cmd package

### DIFF
--- a/cmd/oras-mcp/main_test.go
+++ b/cmd/oras-mcp/main_test.go
@@ -1,0 +1,96 @@
+/*
+Copyright The ORAS Authors.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"bytes"
+	"io"
+	"os"
+	"strings"
+	"testing"
+)
+
+func captureCombinedOutput(t *testing.T, fn func() error) (string, error) {
+	t.Helper()
+
+	originalStdout := os.Stdout
+	originalStderr := os.Stderr
+
+	reader, writer, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("failed to create pipe: %v", err)
+	}
+
+	os.Stdout = writer
+	os.Stderr = writer
+
+	outputCh := make(chan string, 1)
+	go func() {
+		var buf bytes.Buffer
+		if _, copyErr := io.Copy(&buf, reader); copyErr != nil {
+			// io.Copy only returns an error if the read or write fails; close errors are expected
+			t.Logf("io.Copy error: %v", copyErr)
+		}
+		outputCh <- buf.String()
+	}()
+
+	errRun := fn()
+
+	if closeErr := writer.Close(); closeErr != nil {
+		t.Fatalf("failed to close writer: %v", closeErr)
+	}
+
+	os.Stdout = originalStdout
+	os.Stderr = originalStderr
+
+	output := <-outputCh
+
+	if closeErr := reader.Close(); closeErr != nil {
+		t.Fatalf("failed to close reader: %v", closeErr)
+	}
+
+	return output, errRun
+}
+
+func TestRunVersionCommand(t *testing.T) {
+	originalArgs := os.Args
+	os.Args = []string{"oras-mcp", "version"}
+	defer func() {
+		os.Args = originalArgs
+	}()
+
+	output, err := captureCombinedOutput(t, run)
+	if err != nil {
+		t.Fatalf("run returned error: %v", err)
+	}
+
+	if !strings.Contains(output, "Version:") {
+		t.Fatalf("expected output to contain version information, got: %q", output)
+	}
+}
+
+func TestRunUnknownCommand(t *testing.T) {
+	originalArgs := os.Args
+	os.Args = []string{"oras-mcp", "nonexistent"}
+	defer func() {
+		os.Args = originalArgs
+	}()
+
+	_, err := captureCombinedOutput(t, run)
+	if err == nil {
+		t.Fatalf("expected an error for unknown command")
+	}
+}

--- a/cmd/oras-mcp/root/cmd_test.go
+++ b/cmd/oras-mcp/root/cmd_test.go
@@ -1,0 +1,76 @@
+/*
+Copyright The ORAS Authors.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package root
+
+import (
+	"bytes"
+	"context"
+	"testing"
+)
+
+func TestNewRootCommand(t *testing.T) {
+	t.Parallel()
+
+	cmd := New()
+
+	if cmd.Use != "oras-mcp [command]" {
+		t.Fatalf("unexpected use: %q", cmd.Use)
+	}
+
+	if !cmd.SilenceUsage {
+		t.Fatalf("expected SilenceUsage to be true")
+	}
+
+	subCommands := cmd.Commands()
+	if len(subCommands) != 2 {
+		t.Fatalf("expected two subcommands, got %d", len(subCommands))
+	}
+
+	serveCmd, _, err := cmd.Find([]string{"serve"})
+	if err != nil {
+		t.Fatalf("serve command not registered: %v", err)
+	}
+	if serveCmd.Use != "serve" {
+		t.Fatalf("unexpected serve command use: %q", serveCmd.Use)
+	}
+
+	versionCmd, _, err := cmd.Find([]string{"version"})
+	if err != nil {
+		t.Fatalf("version command not registered: %v", err)
+	}
+	if versionCmd.Use != "version" {
+		t.Fatalf("unexpected version command use: %q", versionCmd.Use)
+	}
+
+	cmd.SetArgs([]string{"version"})
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.SetOut(&stdout)
+	cmd.SetErr(&stderr)
+	cmd.SetContext(context.Background())
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("expected version subcommand to execute successfully, got error: %v", err)
+	}
+
+	if stdout.Len() == 0 {
+		t.Fatalf("expected output from version subcommand")
+	}
+
+	if stderr.Len() != 0 {
+		t.Fatalf("did not expect stderr output, got %q", stderr.String())
+	}
+}

--- a/cmd/oras-mcp/root/serve_test.go
+++ b/cmd/oras-mcp/root/serve_test.go
@@ -1,0 +1,133 @@
+/*
+Copyright The ORAS Authors.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package root
+
+import (
+	"context"
+	"errors"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/google/jsonschema-go/jsonschema"
+	"github.com/oras-project/oras-mcp/internal/tool"
+	"github.com/spf13/cobra"
+)
+
+func TestServeCommandDefinition(t *testing.T) {
+	t.Parallel()
+
+	cmd := serveCmd()
+
+	if cmd.Use != "serve" {
+		t.Fatalf("unexpected use: %q", cmd.Use)
+	}
+
+	if cmd.Args == nil {
+		t.Fatalf("expected Args validation function to be defined")
+	}
+
+	if err := cmd.Args(cmd, []string{"unexpected"}); err == nil {
+		t.Fatalf("expected error when arguments are provided")
+	}
+
+	if cmd.RunE == nil {
+		t.Fatalf("expected RunE to be defined")
+	}
+}
+
+func TestRunServeReturnsErrorOnCanceledContext(t *testing.T) {
+	originalSchema := tool.MetadataListReferrers.OutputSchema
+	tool.MetadataListReferrers.OutputSchema = &jsonschema.Schema{Type: "object"}
+	t.Cleanup(func() {
+		tool.MetadataListReferrers.OutputSchema = originalSchema
+	})
+
+	originalStdin := os.Stdin
+	originalStdout := os.Stdout
+	originalStderr := os.Stderr
+
+	t.Cleanup(func() {
+		os.Stdin = originalStdin
+		os.Stdout = originalStdout
+		os.Stderr = originalStderr
+	})
+
+	stdinReader, stdinWriter, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("failed to create stdin pipe: %v", err)
+	}
+	if err := stdinWriter.Close(); err != nil {
+		t.Fatalf("failed to close stdin writer: %v", err)
+	}
+	os.Stdin = stdinReader
+	t.Cleanup(func() {
+		if err := stdinReader.Close(); err != nil && !errors.Is(err, os.ErrClosed) {
+			t.Errorf("failed to close stdin reader: %v", err)
+		}
+	})
+
+	tempDir := t.TempDir()
+
+	// The MCP stdio transport expects real OS file descriptors (it calls
+	// syscalls such as Fd()), so we redirect stdout/stderr to temporary files
+	// instead of using in-memory buffers. The files keep the transport happy
+	// while still letting us inspect output after the server returns. We could
+	// also use additional pipes here, but temp files are perfectly adequate
+	// and keep the test simple.
+	stdoutFile, err := os.CreateTemp(tempDir, "stdout")
+	if err != nil {
+		t.Fatalf("failed to create stdout file: %v", err)
+	}
+	t.Cleanup(func() {
+		if err := stdoutFile.Close(); err != nil && !errors.Is(err, os.ErrClosed) {
+			t.Errorf("failed to close stdout file: %v", err)
+		}
+	})
+
+	stderrFile, err := os.CreateTemp(tempDir, "stderr")
+	if err != nil {
+		t.Fatalf("failed to create stderr file: %v", err)
+	}
+	t.Cleanup(func() {
+		if err := stderrFile.Close(); err != nil && !errors.Is(err, os.ErrClosed) {
+			t.Errorf("failed to close stderr file: %v", err)
+		}
+	})
+
+	os.Stdout = stdoutFile
+	os.Stderr = stderrFile
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	cmd := &cobra.Command{}
+	cmd.SetContext(ctx)
+
+	errCh := make(chan error, 1)
+	go func() {
+		errCh <- runServe(cmd)
+	}()
+
+	select {
+	case err := <-errCh:
+		if err == nil {
+			t.Fatalf("expected error when context is canceled")
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatalf("runServe did not return within timeout")
+	}
+}

--- a/cmd/oras-mcp/root/version_test.go
+++ b/cmd/oras-mcp/root/version_test.go
@@ -1,0 +1,90 @@
+/*
+Copyright The ORAS Authors.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package root
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	"github.com/oras-project/oras-mcp/cmd/oras-mcp/internal/output"
+	"github.com/oras-project/oras-mcp/internal/version"
+)
+
+func TestRunVersionIncludesMetadata(t *testing.T) {
+	originalVersion := version.Version
+	originalBuild := version.BuildMetadata
+	originalCommit := version.GitCommit
+	originalTreeState := version.GitTreeState
+
+	version.Version = "1.2.3"
+	version.BuildMetadata = ""
+	version.GitCommit = "abc1234"
+	version.GitTreeState = "dirty"
+
+	t.Cleanup(func() {
+		version.Version = originalVersion
+		version.BuildMetadata = originalBuild
+		version.GitCommit = originalCommit
+		version.GitTreeState = originalTreeState
+	})
+
+	var out bytes.Buffer
+	var errOut bytes.Buffer
+	printer := output.NewPrinter(&out, &errOut)
+
+	if err := runVersion(printer); err != nil {
+		t.Fatalf("runVersion returned error: %v", err)
+	}
+
+	output := out.String()
+	if !strings.Contains(output, "Version:") || !strings.Contains(output, "1.2.3") {
+		t.Fatalf("expected version information in output, got %q", output)
+	}
+	if !strings.Contains(output, "Git commit:") || !strings.Contains(output, "abc1234") {
+		t.Fatalf("expected git commit in output, got %q", output)
+	}
+	if !strings.Contains(output, "Git tree state:") || !strings.Contains(output, "dirty") {
+		t.Fatalf("expected git tree state in output, got %q", output)
+	}
+
+	if errOut.Len() != 0 {
+		t.Fatalf("expected no error output, got %q", errOut.String())
+	}
+}
+
+func TestVersionCommandExecution(t *testing.T) {
+	cmd := versionCmd()
+
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+
+	cmd.SetOut(&stdout)
+	cmd.SetErr(&stderr)
+	cmd.SetArgs([]string{})
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("version command returned error: %v", err)
+	}
+
+	if stdout.Len() == 0 {
+		t.Fatalf("expected output from version command execution")
+	}
+
+	if stderr.Len() != 0 {
+		t.Fatalf("expected no stderr output, got %q", stderr.String())
+	}
+}


### PR DESCRIPTION
## Summary
- add CLI entrypoint tests covering `run` invocation for the `version` command and unknown commands
- expand root command coverage to verify subcommand registration and version output formatting
- ensure `runServe` surfaces errors when the serving context is canceled while preserving MCP stdio expectations

## Additional context
- Reference: [go scripting](https://oras.land/docs/how_to_guides/go_script) technique is leveraged for unit testing.