### PR TITLE
bump: bump up version of codecov

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -44,7 +44,7 @@ jobs:
       - name: Check Version
         run: bin/linux/amd64/oras-mcp version
       - name: Upload coverage to codecov.io
-        uses: codecov/codecov-action@v4
+        uses: codecov/codecov-action@v5
         env:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
         with:


### PR DESCRIPTION
This pull request updates the Codecov GitHub Action used in the build workflow to a newer major version. This ensures we benefit from the latest features, bug fixes, and security improvements provided by Codecov.

* CI/CD maintenance:
  * Upgraded the Codecov upload action in `.github/workflows/build.yml` from `codecov-action@v4` to `codecov-action@v5` to use the latest version.