### PR TITLE
fix: update ListReferrers output for acyclic schema

### DIFF
--- a/internal/tool/referrers.go
+++ b/internal/tool/referrers.go
@@ -92,10 +92,9 @@ func ListReferrers(ctx context.Context, _ *mcp.CallToolRequest, input InputListR
 		return nil, OutputListReferrers{}, err
 	}
 
-	rootJSON, err := json.Marshal(root)
-	if err != nil {
-		return nil, OutputListReferrers{}, err
-	}
+	// json.Marshal on ListReferrersNode never fails because the structure only
+	// contains JSON-serializable fields; safe to ignore the error.
+	rootJSON, _ := json.Marshal(root)
 
 	output := OutputListReferrers{
 		Data: json.RawMessage(rootJSON),


### PR DESCRIPTION
## Summary
- Pre-marshal the referrers tree into `json.RawMessage` so the MCP Go SDK receives an acyclic schema.
- Update the success path to inline the marshaled tree data and refresh error-path assertions to expect an empty payload.
- Extend the success test to unmarshal the returned JSON and continue validating the nested referrer structure.