### PR TITLE
docs: update README for new implementation

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,9 +2,9 @@
 
 ## Usage
 
-The ORAS MCP Server can be configured to be run using the [vscode agent mode](https://code.visualstudio.com/docs/copilot/chat/chat-agent-mode).
+Configure the ORAS MCP Server to run inside [VS Code agent mode](https://code.visualstudio.com/docs/copilot/chat/chat-agent-mode) for registry-aware chats.
 
-Since this MCP Server requires a local ORAS CLI, please make sure you have installed the [oras](https://github.com/oras-project/oras) (version >= `v1.3.0-beta.1`).
+The server is implemented with the [`oras-go`](https://github.com/oras-project/oras-go) library and does not depend on the [`oras`](https://github.com/oras-project/oras) CLI.
 
 ### Setup with Docker
 
@@ -31,6 +31,15 @@ Add the following code to `.vscode/mcp.json`:
     }
 }
 ```
+
+### Authentication
+
+If you need to access private registries through the server, log in ahead of time using either the ORAS CLI or Docker:
+
+- `oras login <registry>`
+- `docker login <registry>`
+
+The server will reuse the credentials from your local credential store when available.
 
 ## Example Chats
 


### PR DESCRIPTION
## Summary
- Refresh the MCP server README to clarify how it plugs into VS Code agent mode.
- Document that the server is now powered by `oras-go` and no longer requires the `oras` CLI.
- Add guidance for authenticating against private registries and explain credential reuse.

## Changes
- Reword the usage section to emphasize configuration inside VS Code agent mode.
- Update dependency messaging to reflect the shift from the CLI to the `oras-go` library.
- Introduce an explicit authentication section with `oras` and `docker` login examples and note on credential reuse.

## Testing
- Not run (documentation-only change)

## Notes
- No code or dependency modifications are included; the update is purely informational.