### PR TITLE
fix: fix schema validation failure

### DIFF
--- a/internal/tool/blob_test.go
+++ b/internal/tool/blob_test.go
@@ -26,9 +26,35 @@ import (
 	"syscall"
 	"testing"
 
+	"github.com/google/jsonschema-go/jsonschema"
 	"github.com/opencontainers/go-digest"
 	"oras.land/oras-go/v2/content"
 )
+
+func TestFetchBlob_OutputSchema(t *testing.T) {
+	rawSchema := MetadataFetchBlob.OutputSchema
+	if rawSchema == nil {
+		t.Fatal("OutputSchema is nil")
+	}
+
+	schema, ok := rawSchema.(*jsonschema.Schema)
+	if !ok {
+		t.Fatalf("OutputSchema has unexpected type %T", rawSchema)
+	}
+
+	if schema.Type != "object" {
+		t.Fatalf("unexpected schema type: got %q, want %q", schema.Type, "object")
+	}
+	if schema.Description != "Blob data in JSON format." {
+		t.Fatalf("unexpected schema description: got %q", schema.Description)
+	}
+	if schema.AdditionalProperties == nil {
+		t.Fatal("AdditionalProperties is nil")
+	}
+	if schema.AdditionalProperties.Type != "" || schema.AdditionalProperties.Description != "" {
+		t.Fatalf("AdditionalProperties should be unconstrained, got %+v", schema.AdditionalProperties)
+	}
+}
 
 func TestFetchBlob_Success(t *testing.T) {
 	blob := []byte(`{"hello":"world"}`)
@@ -75,8 +101,8 @@ func TestFetchBlob_Success(t *testing.T) {
 	if result != nil {
 		t.Fatalf("expected MCP result to be nil, got %v", result)
 	}
-	if !bytes.Equal(output.Data, blob) {
-		t.Fatalf("unexpected blob data: got %s, want %s", string(output.Data), string(blob))
+	if !bytes.Equal(output.Raw(), blob) {
+		t.Fatalf("unexpected blob data: got %s, want %s", string(output.Raw()), string(blob))
 	}
 }
 
@@ -126,8 +152,8 @@ func TestFetchBlob_InvalidInput(t *testing.T) {
 			if result != nil {
 				t.Fatalf("expected MCP result to be nil, got %v", result)
 			}
-			if len(output.Data) != 0 {
-				t.Fatalf("expected empty output on error, got %s", string(output.Data))
+			if len(output.Raw()) != 0 {
+				t.Fatalf("expected empty output on error, got %s", string(output.Raw()))
 			}
 		})
 	}
@@ -153,8 +179,8 @@ func TestFetchBlob_RemoteError(t *testing.T) {
 	if result != nil {
 		t.Fatalf("expected MCP result to be nil, got %v", result)
 	}
-	if len(output.Data) != 0 {
-		t.Fatalf("expected empty output on error, got %s", string(output.Data))
+	if len(output.Raw()) != 0 {
+		t.Fatalf("expected empty output on error, got %s", string(output.Raw()))
 	}
 }
 
@@ -202,8 +228,8 @@ func TestFetchBlob_NonJSONBlob(t *testing.T) {
 	if result != nil {
 		t.Fatalf("expected MCP result to be nil, got %v", result)
 	}
-	if len(output.Data) != 0 {
-		t.Fatalf("expected empty output on error, got %s", string(output.Data))
+	if len(output.Raw()) != 0 {
+		t.Fatalf("expected empty output on error, got %s", string(output.Raw()))
 	}
 }
 
@@ -253,8 +279,8 @@ func TestFetchBlob_BlobTooLarge(t *testing.T) {
 	if result != nil {
 		t.Fatalf("expected MCP result to be nil, got %v", result)
 	}
-	if len(output.Data) != 0 {
-		t.Fatalf("expected empty output on error, got %s", string(output.Data))
+	if len(output.Raw()) != 0 {
+		t.Fatalf("expected empty output on error, got %s", string(output.Raw()))
 	}
 }
 
@@ -309,7 +335,7 @@ func TestFetchBlob_DigestMismatch(t *testing.T) {
 	if result != nil {
 		t.Fatalf("expected MCP result to be nil, got %v", result)
 	}
-	if len(output.Data) != 0 {
-		t.Fatalf("expected empty output on error, got %s", string(output.Data))
+	if len(output.Raw()) != 0 {
+		t.Fatalf("expected empty output on error, got %s", string(output.Raw()))
 	}
 }

--- a/internal/tool/blob_test.go
+++ b/internal/tool/blob_test.go
@@ -18,6 +18,7 @@ package tool
 import (
 	"bytes"
 	"context"
+	"encoding/json"
 	"errors"
 	"net/http"
 	"net/http/httptest"
@@ -53,6 +54,28 @@ func TestFetchBlob_OutputSchema(t *testing.T) {
 	}
 	if schema.AdditionalProperties.Type != "" || schema.AdditionalProperties.Description != "" {
 		t.Fatalf("AdditionalProperties should be unconstrained, got %+v", schema.AdditionalProperties)
+	}
+}
+
+func TestOutputFetchBlob_MarshalJSON(t *testing.T) {
+	blob := []byte(`{"key":"value"}`)
+	output := OutputFetchBlob{blob: json.RawMessage(blob)}
+
+	got, err := json.Marshal(output)
+	if err != nil {
+		t.Fatalf("json.Marshal() error = %v", err)
+	}
+	if !bytes.Equal(got, blob) {
+		t.Fatalf("unexpected marshal output: got %s, want %s", string(got), string(blob))
+	}
+
+	var zero OutputFetchBlob
+	got, err = json.Marshal(zero)
+	if err != nil {
+		t.Fatalf("json.Marshal() zero error = %v", err)
+	}
+	if string(got) != "null" {
+		t.Fatalf("unexpected zero marshal output: got %s, want null", string(got))
 	}
 }
 

--- a/internal/tool/manifest_test.go
+++ b/internal/tool/manifest_test.go
@@ -18,6 +18,7 @@ package tool
 import (
 	"bytes"
 	"context"
+	"encoding/json"
 	"net/http"
 	"net/http/httptest"
 	"strconv"
@@ -50,6 +51,28 @@ func TestFetchManifest_OutputSchema(t *testing.T) {
 	}
 	if schema.AdditionalProperties.Type != "" || schema.AdditionalProperties.Description != "" {
 		t.Fatalf("AdditionalProperties should be unconstrained, got %+v", schema.AdditionalProperties)
+	}
+}
+
+func TestOutputFetchManifest_MarshalJSON(t *testing.T) {
+	manifest := []byte(`{"schemaVersion":2}`)
+	output := OutputFetchManifest{manifest: json.RawMessage(manifest)}
+
+	got, err := json.Marshal(output)
+	if err != nil {
+		t.Fatalf("json.Marshal() error = %v", err)
+	}
+	if !bytes.Equal(got, manifest) {
+		t.Fatalf("unexpected marshal output: got %s, want %s", string(got), string(manifest))
+	}
+
+	var zero OutputFetchManifest
+	got, err = json.Marshal(zero)
+	if err != nil {
+		t.Fatalf("json.Marshal() zero error = %v", err)
+	}
+	if string(got) != "null" {
+		t.Fatalf("unexpected zero marshal output: got %s, want null", string(got))
 	}
 }
 

--- a/internal/tool/referrers_test.go
+++ b/internal/tool/referrers_test.go
@@ -16,6 +16,7 @@ limitations under the License.
 package tool
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"errors"
@@ -53,6 +54,28 @@ func TestListReferrers_OutputSchema(t *testing.T) {
 	}
 	if schema.AdditionalProperties.Type != "" || schema.AdditionalProperties.Description != "" {
 		t.Fatalf("AdditionalProperties should be unconstrained, got %+v", schema.AdditionalProperties)
+	}
+}
+
+func TestOutputListReferrers_MarshalJSON(t *testing.T) {
+	tree := []byte("{\"digest\":\"sha256:abc\",\"referrers\":[]}")
+	output := OutputListReferrers{tree: json.RawMessage(tree)}
+
+	got, err := json.Marshal(output)
+	if err != nil {
+		t.Fatalf("json.Marshal() error = %v", err)
+	}
+	if !bytes.Equal(got, tree) {
+		t.Fatalf("unexpected marshal output: got %s, want %s", string(got), string(tree))
+	}
+
+	var zero OutputListReferrers
+	got, err = json.Marshal(zero)
+	if err != nil {
+		t.Fatalf("json.Marshal() zero error = %v", err)
+	}
+	if string(got) != "null" {
+		t.Fatalf("unexpected zero marshal output: got %s, want null", string(got))
 	}
 }
 


### PR DESCRIPTION
## Summary
- fix #31
- expose JSON schemas for the blob, manifest, and referrers MCP tools so clients can validate responses
- revise tool outputs to marshal their pre-encoded JSON payloads directly while providing `Raw()` helpers for callers
- expand unit coverage with schema assertions and updated expectations for the new accessors

## Testing
- Tested with live servers