### PR TITLE
bump: tag and release oras-mcp v0.2.1

### DIFF
--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -17,7 +17,7 @@ package version
 
 var (
 	// Version is the current version of the oras-mcp.
-	Version = "0.2.0"
+	Version = "0.2.1"
 	// BuildMetadata is the extra build time data
 	BuildMetadata = "unreleased"
 	// GitCommit is the git sha1


### PR DESCRIPTION
This PR proposes tagging and releasing `v0.2.1` based on commit 34e631aee4ccb6e67ee6ef56f4e95220175f7e85. Approval from at least 2 of the 2 owners listed below is required:

* [x] @shizhMSFT
* [x] @Wwwsylvia

Please approve on the **PR** or request changes (with reasoning).

Changelog: https://github.com/oras-project/oras-mcp/compare/v0.2.0...34e631aee4ccb6e67ee6ef56f4e95220175f7e85